### PR TITLE
Support "wrap around" DOW

### DIFF
--- a/cronsim/cronsim.py
+++ b/cronsim/cronsim.py
@@ -113,6 +113,11 @@ class Field(IntEnum):
             start = self.int(start_str)
             end = self.int(end_str)
 
+            # Support wrap-around DOW ranges such as fri-sun
+            if end < start and self == Field.DOW:
+                wrap = max(RANGES[self])
+                return set(d % wrap for d in range(start, wrap + end + 1))
+
             if end < start:
                 raise CronSimError(self.msg())
 

--- a/tests/test_cronsim.py
+++ b/tests/test_cronsim.py
@@ -113,6 +113,14 @@ class TestParse(unittest.TestCase):
         w = CronSim("* * * * sun-tue", NOW)
         self.assertEqual(w.weekdays, {0, 1, 2})
 
+    def test_it_parses_fri_sun(self) -> None:
+        w = CronSim("* * * * fri-sun", NOW)
+        self.assertEqual(w.weekdays, {0, 5, 6})
+
+    def test_it_parses_fri_tue(self) -> None:
+        w = CronSim("* * * * fri-tue", NOW)
+        self.assertEqual(w.weekdays, {0, 1, 2, 5, 6})
+
     def test_it_starts_weekday_step_from_zero(self) -> None:
         w = CronSim("* * * * */2", NOW)
         self.assertEqual(w.weekdays, {0, 2, 4, 6})


### PR DESCRIPTION
This adds support for crontab's that include a day of week range where the "end" is earlier than the "start".

A few examples could be:

`FRI-MON`: Friday, Saturday, Sunday, Monday `{5, 6, 0, 1}`
`TUE-SUN`: Tuesday, Wednesday, Thurssday, Friday, Saturday, Sunday `{2, 3, 4, 5, 6, 0}`