### PR TITLE
Business days/times support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 stash
 venv
 .venv
+.*.swp
+.exrc
+.mise.*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .*.swp
 .exrc
 .mise.*
+build/

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ for examples of this special handling.
 | "LW" as the day-of-month             | No     | Yes    | No       | Yes     |
 | "L" in the day-of-week field         | No     | Yes    | No       | Yes     |
 | Nth weekday of month                 | No     | Yes    | Yes      | Yes     |
+| "FB" as the day-of-month             | No     |  No    |  No      | Yes     |
+| "LB" as the day-of-month             | No     |  No    |  No      | Yes     |
+| "FB" as the day-of-week              | No     |  No    |  No      | Yes     |
+| "LB" as the day-of-week              | No     |  No    |  No      | Yes     |
+| "B" as the day-of-week               | No     |  No    |  No      | Yes     |
+| "EB" as the hour/minute              | No     |  No    |  No      | Yes     |
 
 
 **Seconds in the 6th field**: an optional sixth field specifying seconds.
@@ -171,6 +177,47 @@ For example, "MON#1" means "first Monday of the month", "MON#2" means "second Mo
 of the month".
 
 Example: `0 0 * * MON#1` (at midnight of the first monday of every month).
+
+**"B"/"LB"/"FB" in the day-of-week field**: interpreted as "the business/last
+business/first business day of the week".
+
+Example: `0 0 * * LB` (at the midnight of the last business day of every week).
+
+**"LB"/"FB" in the day-of-month field**: interpreted as "the last/first
+business day of the month".
+
+Example: `0 0 FB * *` (at the midnight of the first business day of every month).
+
+**"EB" in the hours/minutes field**: interpreted as "end of day time". If "EB"
+is used in hours field then minutes should be `EB` or `*` which are interpreted
+the same way.
+
+Example: `* EB * * 5` (at the end of day every Friday).
+
+## Business days/hours
+
+In order to use business days/hours features you need to provide your own
+implementation for the `BusinessDaysCalendar` class which defines which days
+are business days and also defines end of day times.
+
+```
+class BusinessDaysCalendar(ABC):
+    @abstractmethod
+    def is_business_day(self, d: date) -> bool:
+        pass
+
+    @abstractmethod
+    def get_previous_business_day(self, d: date) -> date:
+        pass
+
+    @abstractmethod
+    def get_next_business_day(self, d: date) -> date:
+        pass
+
+    @abstractmethod
+    def get_end_of_day(self, dt: datetime) -> datetime:
+        pass
+```
 
 ## The `explain()` Method
 

--- a/README.md
+++ b/README.md
@@ -188,11 +188,9 @@ business day of the month".
 
 Example: `0 0 FB * *` (at the midnight of the first business day of every month).
 
-**"EB" in the hours/minutes field**: interpreted as "end of day time". If "EB"
-is used in hours field then minutes should be `EB` or `*` which are interpreted
-the same way.
+**"EB" in the hours and minutes field**: interpreted as "end of day time". 
 
-Example: `* EB * * 5` (at the end of day every Friday).
+Example: `EB EB * * 5` (at the end of day every Friday).
 
 ## Business days/hours
 

--- a/cronsim/__init__.py
+++ b/cronsim/__init__.py
@@ -1,1 +1,5 @@
-from .cronsim import CronSim as CronSim, CronSimError as CronSimError
+from .cronsim import (
+    BusinessDaysCalendar as BusinessDaysCalendar,
+    CronSim as CronSim,
+    CronSimError as CronSimError,
+)

--- a/cronsim/cronsim.py
+++ b/cronsim/cronsim.py
@@ -78,6 +78,8 @@ class Field(IntEnum):
                 return {CronSim.LAST_WEEK_BUSINESSDAY}
             elif s == "FB":
                 return {CronSim.FIRST_WEEK_BUSINESSDAY}
+            elif s == "B":
+                return {CronSim.BUSINESSDAY}
             elif "L" in s:
                 value = s[:-1]
                 if not value.isdigit():
@@ -187,6 +189,7 @@ class CronSim:
     LAST_WEEK_BUSINESSDAY = -1004
     FIRST_WEEK_BUSINESSDAY = -1005
     END_OF_BUSINESSDAY = -1006
+    BUSINESSDAY = -1007
 
     def __init__(
             self,
@@ -246,7 +249,9 @@ class CronSim:
             if self.END_OF_BUSINESSDAY in self.hours:
                 raise CronSimError(Field.HOUR.msg())
 
-        self.match_business_day = self.END_OF_BUSINESSDAY in self.hours
+        self.match_business_day = (
+            self.END_OF_BUSINESSDAY in self.hours or self.BUSINESSDAY in self.weekdays
+        )
 
         self.business_days_calendar = business_days_calendar
 
@@ -460,6 +465,10 @@ class CronSim:
             if d.day + 7 > last:
                 # Same day next week would be outside this month.
                 # So this is the last one this month.
+                return True
+
+        if self.BUSINESSDAY in self.weekdays:
+            if self.business_days_calendar.is_business_day(d):
                 return True
 
         if self.FIRST_WEEK_BUSINESSDAY in self.weekdays:

--- a/cronsim/cronsim.py
+++ b/cronsim/cronsim.py
@@ -177,7 +177,7 @@ class BusinessDaysCalendar(ABC):
         pass
 
     @abstractmethod
-    def get_end_of_day(self, dt: datetime) -> datetime:
+    def get_end_of_day(self, d: date) -> datetime:
         pass
 
 
@@ -272,7 +272,7 @@ class CronSim:
     def match_minute(self, dt: datetime) -> bool:
         """Return True is minute matches."""
         if self.END_OF_BUSINESSDAY in self.minutes:
-            if dt.minute == self.business_days_calendar.get_end_of_day(dt).minute:
+            if dt.minute == self.get_end_of_day(dt.date()).minute:
                 return True
         else:
             if dt.minute in self.minutes:
@@ -335,7 +335,7 @@ class CronSim:
             return True
 
         if self.END_OF_BUSINESSDAY in self.hours:
-            if dt.hour == self.business_days_calendar.get_end_of_day(dt).hour:
+            if dt.hour == self.get_end_of_day(dt.date()).hour:
                 return True
 
         return False
@@ -374,6 +374,10 @@ class CronSim:
                 break
 
         return True
+
+    @lru_cache(maxsize=128)
+    def get_end_of_day(self, d: date) -> datetime:
+        return self.business_days_calendar.get_end_of_day(d)
 
     def get_first_business_day_of_week(self, d: date) -> date | None:
         """

--- a/cronsim/cronsim.py
+++ b/cronsim/cronsim.py
@@ -210,13 +210,13 @@ class CronSim:
         # Otherwise it's "OR".
         self.day_and = self.parts[2].startswith("*") or self.parts[4].startswith("*")
 
+        self.minutes = cast(set[int], Field.MINUTE.parse(self.parts[0]))
         self.hours = cast(set[int], Field.HOUR.parse(self.parts[1]))
-        if self.END_OF_BUSINESSDAY in self.hours:
-            if self.parts[0] not in ["*", "EB"]:
+        if (self.END_OF_BUSINESSDAY in self.hours) != (self.END_OF_BUSINESSDAY in self.minutes):
+            if self.END_OF_BUSINESSDAY in self.hours:
                 raise CronSimError(Field.MINUTE.msg())
-            self.minutes = {self.END_OF_BUSINESSDAY}
-        else:
-            self.minutes = cast(set[int], Field.MINUTE.parse(self.parts[0]))
+            else:
+                raise CronSimError(Field.HOUR.msg())
         self.days = cast(set[int], Field.DAY.parse(self.parts[2]))
         self.months = cast(set[int], Field.MONTH.parse(self.parts[3]))
         self.weekdays = Field.DOW.parse(self.parts[4])

--- a/tests/test_cronsim.py
+++ b/tests/test_cronsim.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 from datetime import datetime, timezone, timedelta
 from itertools import product
-from typing import Iterator, Sequence
+from typing import Generator, Iterator, Sequence
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
@@ -51,9 +51,9 @@ class BusinessDaysCalendarWithBankHolidays(BusinessDaysCalendar):
             d += timedelta(days=1)
         return d
 
-    def get_end_of_day(self, dt: datetime) -> datetime:
-        if dt.date() in self.eod_times:
-            eod_time = self.eod_times[dt.date()]
+    def get_end_of_day(self, dt: date) -> datetime:
+        if dt in self.eod_times:
+            eod_time = self.eod_times[dt]
         else:
             eod_time = self.eod_time
         return datetime.combine(dt, eod_time)

--- a/tests/test_cronsim.py
+++ b/tests/test_cronsim.py
@@ -1016,9 +1016,24 @@ class TestOptimizations(unittest.TestCase):
 
 
 class TestExplain(unittest.TestCase):
+    business_days_samples = [
+        ("* * fb * *",  "Every minute on the first business day of every month"),
+        ("* * lb * *",  "Every minute on the last business day of every month"),
+        ("* * * * fb",  "Every minute on the first business day of every week"),
+        ("* * * * lb",  "Every minute on the last business day of every week"),
+        ("* * * * b",  "Every minute on every business day of every week"),
+        ("* * * * b",  "Every minute on every business day of every week"),
+        ("eb eb * * *",  "At the end of day every day"),
+        ("* eb * * *",  "At the end of day every day"),
+    ]
     def test_it_works(self) -> None:
         result = CronSim("* * * * *", NOW).explain()
         self.assertEqual(result, "Every minute")
+
+    def test_business_days(self) -> None:
+        for cron_expr, expected_explain in self.business_days_samples:
+            cron_sim = CronSim(cron_expr, NOW, business_days_calendar=BUSINESS_CALENDAR)
+            self.assertEqual(cron_sim.explain(), expected_explain)
 
 
 class TestReverse(unittest.TestCase):


### PR DESCRIPTION
This adds support for business days/times. Here's a quote from the readme:

**"B"/"LB"/"FB" in the day-of-week field**: interpreted as "the business/last
business/first business day of the week".

Example: `0 0 * * LB` (at the midnight of the last business day of every week).

**"LB"/"FB" in the day-of-month field**: interpreted as "the last/first
business day of the month".

Example: `0 0 FB * *` (at the midnight of the first business day of every month).

**"EB" in the hours and minutes fields**: interpreted as "end of day time".

Example: `EB EB * * 5` (at the end of day every Friday).

## Business days/hours

In order to use business days/hours features you need to provide your own
implementation for the `BusinessDaysCalendar` class which defines which days
are business days and also defines end of day times.

```
class BusinessDaysCalendar(ABC):
    @abstractmethod
    def is_business_day(self, d: date) -> bool:
        pass
    @abstractmethod
    def get_previous_business_day(self, d: date) -> date:
        pass
    @abstractmethod
    def get_next_business_day(self, d: date) -> date:
        pass
    @abstractmethod
    def get_end_of_day(self, d: date) -> datetime:
        pass
```

## Future work

Optimizations to advance functions should be added when searching for next business day and EOD.